### PR TITLE
Add amd64 assembly version of swapUint64()

### DIFF
--- a/endian_test.go
+++ b/endian_test.go
@@ -43,3 +43,27 @@ func TestConversion(t *testing.T) {
 		t.Errorf("Invalid conversion yielded 0x%x", u64)
 	}
 }
+
+func Benchmark16_1000(b *testing.B) {
+	for b.Loop() {
+		for i := 0; i < 1000; i++ {
+			endian.HostToNetUint16(0xAABB)
+		}
+	}
+}
+
+func Benchmark32_1000(b *testing.B) {
+	for b.Loop() {
+		for i := 0; i < 1000; i++ {
+			endian.HostToNetUint32(0xAABBCCDD)
+		}
+	}
+}
+
+func Benchmark64_1000(b *testing.B) {
+	for b.Loop() {
+		for i := 0; i < 1000; i++ {
+			endian.HostToNetUint64(0xAABBCCDDEEFF4288)
+		}
+	}
+}

--- a/uint16_little.go
+++ b/uint16_little.go
@@ -1,0 +1,13 @@
+// Copyright (C) 2015  The endian Authors.  All rights reserved.
+// This file is part of the Go endian library.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the COPYING file.
+
+// +build 386 amd64 amd64p32 arm arm64 ppc64le mipsle mips64le mips64p32le
+
+package endian
+
+// swapUint16 converts a uint16 to network byte order and back.
+func swapUint16(n uint16) uint16 {
+	return (n&0x00FF)<<8 | (n&0xFF00)>>8
+}

--- a/uint32_little.go
+++ b/uint32_little.go
@@ -1,0 +1,14 @@
+// Copyright (C) 2015  The endian Authors.  All rights reserved.
+// This file is part of the Go endian library.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the COPYING file.
+
+// +build 386 amd64 amd64p32 arm arm64 ppc64le mipsle mips64le mips64p32le
+
+package endian
+
+// swapUint32 converts a uint16 to network byte order and back.
+func swapUint32(n uint32) uint32 {
+	return (n&0x000000FF)<<24 | (n&0x0000FF00)<<8 |
+		(n&0x00FF0000)>>8 | (n&0xFF000000)>>24
+}

--- a/uint64_amd64.go
+++ b/uint64_amd64.go
@@ -1,0 +1,11 @@
+// Copyright (C) 2025  The endian Authors.  All rights reserved.
+// This file is part of the Go endian library.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the COPYING file.
+
+// +build !noasm
+
+package endian
+
+// implemented in uint64_amd64.s
+func swapUint64(n uint64) uint64

--- a/uint64_amd64.s
+++ b/uint64_amd64.s
@@ -1,0 +1,15 @@
+// Copyright (C) 2025  The endian Authors.  All rights reserved.
+// This file is part of the Go endian library.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the COPYING file.
+
+// +build !noasm
+
+#include "textflag.h"
+
+// func swapUint64(n uint64) uint64
+TEXT ·swapUint64(SB), NOSPLIT, $0
+	MOVQ n+0(FP), AX
+	BSWAPQ AX
+	MOVQ  AX, ret+8(FP)
+	RET

--- a/uint64_little.go
+++ b/uint64_little.go
@@ -3,20 +3,9 @@
 // Use of this source code is governed by the Apache License 2.0
 // that can be found in the COPYING file.
 
-// +build 386 amd64 amd64p32 arm arm64 ppc64le mipsle mips64le mips64p32le
+// +build 386 amd64,noasm amd64p32 arm arm64 ppc64le mipsle mips64le mips64p32le
 
 package endian
-
-// swapUint16 converts a uint16 to network byte order and back.
-func swapUint16(n uint16) uint16 {
-	return (n&0x00FF)<<8 | (n&0xFF00)>>8
-}
-
-// swapUint32 converts a uint16 to network byte order and back.
-func swapUint32(n uint32) uint32 {
-	return (n&0x000000FF)<<24 | (n&0x0000FF00)<<8 |
-		(n&0x00FF0000)>>8 | (n&0xFF000000)>>24
-}
 
 // swapUint64 converts a uint16 to network byte order and back.
 func swapUint64(n uint64) uint64 {


### PR DESCRIPTION
I decided to have fun learning how to write assembly code in Go, and this tiny library seemed like a good opportunity.
I originally wrote assembly versions for all three variants (uint16, uint32 and uint64) but the assembly version of swapUint16() and swapUint32() were slower than their Go counterparts. It seems this is because the Go compiler can inline Go functions but not assembly ones.

As the only version that showed some improvements was the uint64 one, I decided to only keep this one.

I added benchmark functions to be able to quantify the improvements, both implementations can be run by specifying (or not) the tag "noasm":

```console
$ go test -bench=.
goos: linux
goarch: amd64
pkg: github.com/tsuna/endian
cpu: 13th Gen Intel(R) Core(TM) i9-13900
Benchmark16_1000-32    	 2306198	       499.8 ns/op
Benchmark32_1000-32    	 1634236	       731.6 ns/op
Benchmark64_1000-32    	 1457139	       824.8 ns/op
PASS
ok  	github.com/tsuna/endian	3.557s
```

```console
$ go test -bench=. -tags noasm
goos: linux
goarch: amd64
pkg: github.com/tsuna/endian
cpu: 13th Gen Intel(R) Core(TM) i9-13900
Benchmark16_1000-32    	 2263766	       498.6 ns/op
Benchmark32_1000-32    	 1650574	       727.0 ns/op
Benchmark64_1000-32    	  932718	      1267 ns/op
PASS
ok  	github.com/tsuna/endian	3.516s
```