### PR TITLE
Declare a Go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/tsuna/endian
+
+go 1.11


### PR DESCRIPTION
This allows to be compatible with the latest Go toolchains, which use modules by default, thus making running tests easier.
The Go version chosen is the one where the concept of modules have been first introduced.
