### PR TITLE
Add arm64 assembly implementations for 32 & 64 bits

### DIFF
--- a/uint32_arm64.s
+++ b/uint32_arm64.s
@@ -1,0 +1,22 @@
+// Copyright (C) 2025  The endian Authors.  All rights reserved.
+// This file is part of the Go endian library.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the COPYING file.
+
+// +build !noasm
+
+#include "textflag.h"
+
+#define SWAPUINT32 \
+	MOVW n+0(FP), R0;   \
+	REV32 R0, R1;       \
+	MOVW R1, ret+8(FP); \
+	RET
+
+// func NetToHostUint32(n uint32) uint32
+TEXT ·NetToHostUint32(SB), NOSPLIT, $0
+	SWAPUINT32
+
+// func HostToNetUint32(n uint32) uint32
+TEXT ·HostToNetUint32(SB), NOSPLIT, $0
+	SWAPUINT32

--- a/uint32_little.go
+++ b/uint32_little.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by the Apache License 2.0
 // that can be found in the COPYING file.
 
-// +build 386 amd64,noasm amd64p32 arm arm64 ppc64le mipsle mips64le mips64p32le
+// +build 386 amd64,noasm amd64p32 arm arm64,noasm ppc64le mipsle mips64le mips64p32le
 
 package endian
 

--- a/uint64_arm64.s
+++ b/uint64_arm64.s
@@ -1,0 +1,22 @@
+// Copyright (C) 2025  The endian Authors.  All rights reserved.
+// This file is part of the Go endian library.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the COPYING file.
+
+// +build !noasm
+
+#include "textflag.h"
+
+#define SWAPUINT64 \
+	MOVD n+0(FP), R0;   \
+	REV R0, R1;         \
+	MOVD R1, ret+8(FP); \
+	RET
+
+// func NetToHostUint64(n uint64) uint64
+TEXT ·NetToHostUint64(SB), NOSPLIT, $0
+	SWAPUINT64
+
+// func HostToNetUint64(n uint64) uint64
+TEXT ·HostToNetUint64(SB), NOSPLIT, $0
+	SWAPUINT64

--- a/uint64_little.go
+++ b/uint64_little.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by the Apache License 2.0
 // that can be found in the COPYING file.
 
-// +build 386 amd64,noasm amd64p32 arm arm64 ppc64le mipsle mips64le mips64p32le
+// +build 386 amd64,noasm amd64p32 arm arm64,noasm ppc64le mipsle mips64le mips64p32le
 
 package endian
 


### PR DESCRIPTION
Here is the arm64 version, tested on RaspberryPi 4 with Linux.

Before

```console
$ go test -bench=. -tags noasm
goos: linux
goarch: arm64
pkg: github.com/tsuna/endian
Benchmark16_1000-4   	  356767	      3354 ns/op
Benchmark32_1000-4   	  305560	      3919 ns/op
Benchmark64_1000-4   	  178471	      6710 ns/op
PASS
ok  	github.com/tsuna/endian	3.600s
```

After

```console
$ go test -bench=.
goos: linux
goarch: arm64
pkg: github.com/tsuna/endian
Benchmark16_1000-4   	  351492	      3359 ns/op
Benchmark32_1000-4   	  356980	      3354 ns/op
Benchmark64_1000-4   	  306332	      3911 ns/op
PASS
ok  	github.com/tsuna/endian	3.585s
```