### PR TITLE
Add loong64 and riscv64 support

### DIFF
--- a/uint16_little.go
+++ b/uint16_little.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by the Apache License 2.0
 // that can be found in the COPYING file.
 
-// +build 386 amd64 amd64p32 arm arm64 ppc64le mipsle mips64le mips64p32le
+// +build 386 amd64 amd64p32 arm arm64 ppc64le mipsle mips64le mips64p32le loong64 riscv64
 
 package endian
 

--- a/uint32_little.go
+++ b/uint32_little.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by the Apache License 2.0
 // that can be found in the COPYING file.
 
-// +build 386 amd64,noasm amd64p32 arm arm64,noasm ppc64le mipsle mips64le mips64p32le
+// +build 386 amd64,noasm amd64p32 arm arm64,noasm ppc64le mipsle mips64le mips64p32le loong64 riscv64
 
 package endian
 

--- a/uint64_little.go
+++ b/uint64_little.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by the Apache License 2.0
 // that can be found in the COPYING file.
 
-// +build 386 amd64,noasm amd64p32 arm arm64,noasm ppc64le mipsle mips64le mips64p32le
+// +build 386 amd64,noasm amd64p32 arm arm64,noasm ppc64le mipsle mips64le mips64p32le loong64 riscv64
 
 package endian
 


### PR DESCRIPTION
These two architectures are built at least by Debian so it makes sense to support them. Both are little endian as seen in the Go sources [1].

[1] https://cs.opensource.google/go/go/+/master:src/encoding/binary/native_endian_little.go;l=5
